### PR TITLE
Add responsive web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Clasificación de frutas
+
+Este proyecto contiene un pequeño modelo de red neuronal (no incluido en el repositorio) y una interfaz web para clasificar imágenes.
+
+## Requisitos
+- Python 3
+- Dependencias listadas en `requirements.txt`
+
+## Ejecutar el servidor
+
+```bash
+pip install -r requirements.txt
+python backend/app.py
+```
+
+El servidor quedará escuchando en `http://localhost:5000/`.
+
+## Probar la interfaz
+
+Abre `frontend/index.html` en tu navegador. Desde la página podrás seleccionar una imagen y enviarla al servidor para obtener una predicción.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,38 @@
+import os
+from flask import Flask, request, jsonify
+from tensorflow.keras.models import load_model
+from tensorflow.keras.preprocessing import image
+import numpy as np
+
+app = Flask(__name__)
+
+MODEL_PATH = os.path.join(os.path.dirname(__file__), '..', 'Proyecto Topicos', 'modelo', 'modelo.h5')
+model = None
+labels = ['clase_0', 'clase_1', 'clase_2', 'clase_3', 'clase_4']
+
+if os.path.exists(MODEL_PATH):
+    model = load_model(MODEL_PATH)
+
+@app.route('/predict', methods=['POST'])
+def predict():
+    if 'image' not in request.files:
+        return jsonify({'error': 'No image provided'}), 400
+
+    file = request.files['image']
+    img = image.load_img(file, target_size=(150, 150))
+    x = image.img_to_array(img) / 255.0
+    x = np.expand_dims(x, axis=0)
+
+    if model:
+        preds = model.predict(x)
+        idx = int(np.argmax(preds[0]))
+        label = labels[idx] if idx < len(labels) else str(idx)
+        confidence = float(preds[0][idx])
+    else:
+        label = 'modelo_no_disponible'
+        confidence = 0.0
+
+    return jsonify({'label': label, 'confidence': confidence})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# Interfaz gráfica
+
+Esta carpeta contiene una interfaz web sencilla diseñada con [Bootstrap](https://getbootstrap.com/) para que la aplicación se vea correctamente tanto en celulares como en tabletas.
+
+Para probarla, primero inicia el servidor en la carpeta `backend` y luego abre `index.html` en tu navegador. La función `clasificarImagen()` envía la imagen al endpoint `/predict` del servidor.
+
+## Características
+- Diseño responsivo que se adapta a distintos tamaños de pantalla.
+- Previsualización de la imagen seleccionada antes de enviarla.
+- Elementos centrados para facilitar su uso en dispositivos móviles.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Clasificación de frutas</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaMoL+lfLdFCEU8U2H6kpLQ7FNKaFUjJoFTmOfedcLKyQBtR7ay1G+8eS3K" crossorigin="anonymous">
+    <style>
+        body {
+            padding-top: 4rem;
+        }
+        .image-preview {
+            max-width: 100%;
+            height: auto;
+        }
+    </style>
+</head>
+<body>
+    <nav class="navbar navbar-dark bg-dark fixed-top">
+        <div class="container-fluid">
+            <span class="navbar-brand mb-0 h1">Clasificación de Frutas</span>
+        </div>
+    </nav>
+
+    <main class="container">
+        <div class="row justify-content-center">
+            <div class="col-12 col-md-6">
+                <h2 class="text-center">Sube una imagen</h2>
+                <input type="file" class="form-control mb-3" id="imageInput" accept="image/*" onchange="previewImage(event)">
+                <img id="preview" class="image-preview mb-3" src="#" alt="Previsualización" style="display:none;" />
+                <button class="btn btn-primary w-100" onclick="clasificarImagen()">Clasificar</button>
+                <div id="resultado" class="mt-3 text-center"></div>
+            </div>
+        </div>
+    </main>
+
+    <script>
+        function previewImage(event) {
+            const input = event.target;
+            if (input.files && input.files[0]) {
+                const reader = new FileReader();
+                reader.onload = function(e) {
+                    const img = document.getElementById('preview');
+                    img.src = e.target.result;
+                    img.style.display = 'block';
+                };
+                reader.readAsDataURL(input.files[0]);
+            }
+        }
+
+        async function clasificarImagen() {
+            const input = document.getElementById('imageInput');
+            const resultado = document.getElementById('resultado');
+
+            if (!input.files || !input.files[0]) {
+                resultado.textContent = 'Primero selecciona una imagen';
+                return;
+            }
+
+            const data = new FormData();
+            data.append('image', input.files[0]);
+
+            resultado.textContent = 'Clasificando...';
+            try {
+                const resp = await fetch('http://localhost:5000/predict', {
+                    method: 'POST',
+                    body: data
+                });
+                const json = await resp.json();
+                if (resp.ok) {
+                    resultado.textContent = `Resultado: ${json.label} (confianza: ${json.confidence.toFixed(2)})`;
+                } else {
+                    resultado.textContent = json.error || 'Error en la predicción';
+                }
+            } catch (err) {
+                resultado.textContent = 'No se pudo conectar con el servidor';
+            }
+        }
+    </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+tensorflow
+pillow


### PR DESCRIPTION
## Summary
- create simple frontend with Bootstrap so the UI adapts to mobile devices
- document how to run the responsive interface
- add Flask backend and wire the interface to a `/predict` endpoint

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6840add4f7bc832e844c15bd6f95cb75